### PR TITLE
use client checksum when writing log

### DIFF
--- a/cluster/cluster_SUITE.erl
+++ b/cluster/cluster_SUITE.erl
@@ -133,7 +133,7 @@ bootstrap(Config) ->
     R1 = vg_client:fetch(<<"foo">>),
     ct:pal("r ~p ~p", [R, R1]),
     timer:sleep(1800),
-    ?assertMatch(#{partitions := [#{message_set := [#{record := <<"bar">>}]}]}, R1),
+    ?assertMatch(#{partitions := [#{record_set := [#{record := <<"bar">>}]}]}, R1),
     Config.
 
 roles(Config) ->

--- a/src/vg_client.erl
+++ b/src/vg_client.erl
@@ -47,17 +47,17 @@ fetch_until(Topic, Position, Target) ->
                         Loop(Resp#{partitions := [Part]})
                 end
         end,
-    Loop(#{topic => Topic, partitions => [#{message_set => [],
+    Loop(#{topic => Topic, partitions => [#{record_set => [],
                                             high_water_mark => Position}]}).
 
 merge_fetch_response(One, Two) ->
     %% TODO: this will need to be more sophisticated to handle
     %% multiple partitions
-    #{partitions := [#{message_set := Set1}]} = One,
-    #{partitions := [#{message_set := Set2} = Part]} = Two,
+    #{partitions := [#{record_set := Set1}]} = One,
+    #{partitions := [#{record_set := Set2} = Part]} = Two,
     %% we assume ordering here, so Two's mark will be larger than
     %% One's, and when we append we'll preserve ordering.
-    Two#{partitions := [Part#{message_set := lists:append(Set1, Set2)}]}.
+    Two#{partitions := [Part#{record_set := lists:append(Set1, Set2)}]}.
 
 produce(Topic, RecordSet) ->
     {ok, Pool} = vg_client_pool:get_pool(Topic, write),

--- a/src/vg_conn.erl
+++ b/src/vg_conn.erl
@@ -93,7 +93,7 @@ terminate(_, _) ->
 
 %% internal
 
-%% If a message can be fully read from the data then handle the request
+%% If a record can be fully read from the data then handle the request
 %% else return the data to be kept in the buffer
 -spec handle_data(binary(), head | solo | tail, inets:socket()) ->
                          {ok, binary()} | {error, any()}.

--- a/test/cleanup_SUITE.erl
+++ b/test/cleanup_SUITE.erl
@@ -31,7 +31,10 @@ delete_policy(_Config) ->
     vg:create_topic(Topic),
     ?assert(filelib:is_dir(TopicPartitionDir)),
 
-    vg:write(Topic, [crypto:strong_rand_bytes(60), crypto:strong_rand_bytes(60)]),
+    RandomRecords = [#{crc => erlang:crc32(M),
+                       record => M}
+                      || M <- [crypto:strong_rand_bytes(60), crypto:strong_rand_bytes(60)]],
+    vg:write(Topic, RandomRecords),
 
     %% Verify 2 segments have been created
     Segment0 = filename:join([TopicPartitionDir, "00000000000000000000.log"]),

--- a/test/log_roll_SUITE.erl
+++ b/test/log_roll_SUITE.erl
@@ -5,7 +5,7 @@
 -compile(export_all).
 
 all() ->
-    [message_set_larger_than_max_segment].
+    [record_set_larger_than_max_segment].
 
 init_per_testcase(_, Config) ->
     PrivDir = ?config(priv_dir, Config),
@@ -24,26 +24,29 @@ end_per_testcase(_, Config) ->
     application:unload(vonnegut),
     Config.
 
-message_set_larger_than_max_segment(_Config) ->
+record_set_larger_than_max_segment(_Config) ->
     Topic = vg_test_utils:create_random_name(<<"log_roll_test_topic">>),
     Partition = 0,
     TopicPartitionDir = vg_utils:topic_dir(Topic, Partition),
     vg:create_topic(Topic),
     ?assert(filelib:is_dir(TopicPartitionDir)),
 
-    vg:write(Topic, [crypto:strong_rand_bytes(60), crypto:strong_rand_bytes(60),
-                     crypto:strong_rand_bytes(6), crypto:strong_rand_bytes(6),
-                     crypto:strong_rand_bytes(60)]),
+    RandomRecords = [#{crc => erlang:crc32(M),
+                        record => M}
+                      || M <- [crypto:strong_rand_bytes(60), crypto:strong_rand_bytes(60),
+                               crypto:strong_rand_bytes(6), crypto:strong_rand_bytes(6),
+                               crypto:strong_rand_bytes(60)]],
+    vg:write(Topic, RandomRecords),
 
-    %% Total size of a 60 byte message when written to log becomes 86 bytes
+    %% Total size of a 60 byte record when written to log becomes 86 bytes
     %% Since index interval is 24 and 86 > 24, 1 index entry of 6 bytes should exist for each as well
     ?assertEqual(filelib:file_size(filename:join([TopicPartitionDir, "00000000000000000000.index"])), 6),
     ?assertEqual(filelib:file_size(filename:join([TopicPartitionDir, "00000000000000000000.log"])), 86),
     ?assertEqual(filelib:file_size(filename:join([TopicPartitionDir, "00000000000000000001.index"])), 6),
     ?assertEqual(filelib:file_size(filename:join([TopicPartitionDir, "00000000000000000001.log"])), 86),
 
-    %% Next 2 messages create a log with 2 messages of 6 bytes each (with headers they are 32 bytes)
-    %% with ids 2 and 3. The third message (id 4) then goes in a new index and log
+    %% Next 2 records create a log with 2 records of 6 bytes each (with headers they are 32 bytes)
+    %% with ids 2 and 3. The third record (id 4) then goes in a new index and log
     ?assertEqual(filelib:file_size(filename:join([TopicPartitionDir, "00000000000000000002.index"])), 12),
     ?assertEqual(filelib:file_size(filename:join([TopicPartitionDir, "00000000000000000002.log"])), 64),
     ?assertEqual(filelib:file_size(filename:join([TopicPartitionDir, "00000000000000000004.index"])), 6),

--- a/test/vg_consumer_SUITE.erl
+++ b/test/vg_consumer_SUITE.erl
@@ -36,11 +36,11 @@ from_zero(_Config) ->
 
     ok = vg_client_pool:start(),
     ?assertMatch(#{topic := Topic, offset := 0},
-                 vg_client:produce(Topic, [<<"message 1 wasn't long enough to make wrapping fail">>,
-                                           <<"message 2">>])),
+                 vg_client:produce(Topic, [<<"record 1 wasn't long enough to make wrapping fail">>,
+                                           <<"record 2">>])),
 
-    #{partitions := [#{message_set := Data}]} = vg_client:fetch_until(Topic, 1),
-    ?assertMatch([#{id := 0, record := <<"message 1 wasn't long enough to make wrapping fail">>},
-                  #{id := 1, record := <<"message 2">>}], Data),
+    #{partitions := [#{record_set := Data}]} = vg_client:fetch_until(Topic, 1),
+    ?assertMatch([#{id := 0, record := <<"record 1 wasn't long enough to make wrapping fail">>},
+                  #{id := 1, record := <<"record 2">>}], Data),
     vg_client_pool:stop(),
     ok.


### PR DESCRIPTION
This change makes it so the checksum isn't calculated by the server but is calculated on the client side.

Also I've made it consistent that we use `record` and `record_set` instead of message.