### PR TITLE
checksum the magicbyte,attributes,record. matching kafka

### DIFF
--- a/src/vg.erl
+++ b/src/vg.erl
@@ -6,8 +6,10 @@
          fetch/2,
          fetch/1]).
 
--type record() :: #{id := integer(),
-                    crc := integer(),
+-include("vg.hrl").
+
+-type record() :: #{id => integer(),
+                    crc => integer(),
                     record := binary() | {binary(), binary()}}.
 -type record_set() :: [record()].
 
@@ -27,10 +29,9 @@ ensure_topic(Topic) ->
 
 -spec write(Topic, Record) -> ok | {error, any()} when
       Topic :: binary(),
-      Record :: binary() | [#{crc := integer(), record := binary()}].
+      Record :: binary() | record_set().
 write(Topic, Record) when is_binary(Record) ->
-    vg_active_segment:write(Topic, 0, [#{crc => erlang:crc32(Record),
-                                         record => Record}]);
+    vg_active_segment:write(Topic, 0, [#{record => Record}]);
 write(Topic, RecordSet) when is_list(RecordSet) ->
     vg_active_segment:write(Topic, 0, RecordSet).
 

--- a/src/vg_active_segment.erl
+++ b/src/vg_active_segment.erl
@@ -40,6 +40,11 @@ start_link(Topic, Partition, NextBrick) ->
     Tab = vg_pending_writes:ensure_tab(Topic, Partition),
     gen_server:start_link(?SERVER(Topic, Partition), ?MODULE, [Topic, Partition, NextBrick, Tab], []).
 
+-spec write(Topic, Partition, RecordSet) -> {ok, Offset} | {error, any()} when
+      Topic :: binary(),
+      Partition :: integer(),
+      RecordSet :: vg:record_set(),
+      Offset :: integer().
 write(Topic, Partition, RecordSet) ->
     %% there clearly needs to be a lot more logic here.  it's also not
     %% clear that this is the right place for this
@@ -166,7 +171,7 @@ code_change(_, State, _) ->
 write_record_set(RecordSet, State=#state{history_tab=Tab}) ->
     {State#state.id, lists:foldl(fun(Record, StateAcc=#state{id=Id,
                                                               byte_count=ByteCount}) ->
-                                     {NextId, Size, Bytes} = vg_protocol:encode_id_record(Id, Record),
+                                     {NextId, Size, Bytes} = vg_protocol:encode_log(Id, Record),
                                      StateAcc1 = #state{pos=Position1} = maybe_roll(Size, StateAcc),
                                      update_log(Bytes, StateAcc1),
                                      StateAcc2 = StateAcc1#state{byte_count=ByteCount+Size},

--- a/src/vg_client.erl
+++ b/src/vg_client.erl
@@ -84,7 +84,7 @@ handle_request({fetch, Topic, Partition, Position}, #state {
     Request = vg_protocol:encode_fetch(ReplicaId, MaxWaitTime, MinBytes, [{Topic, [{Partition, Position, 100}]}]),
     Data = vg_protocol:encode_request(?FETCH_REQUEST, RequestId, ?CLIENT_ID, Request),
 
-    {ok, RequestId, [<<(iolist_size(Data)):32/signed>>, Data],
+    {ok, RequestId, [<<(iolist_size(Data)):32/signed-integer>>, Data],
      State#state{corids = maps:put(RequestId, ?FETCH_REQUEST, CorIds),
                  request_counter = RequestCounter + 1}};
 handle_request({produce, Topic, Partition, Records}, #state {
@@ -99,7 +99,7 @@ handle_request({produce, Topic, Partition, Records}, #state {
     Request = vg_protocol:encode_produce(Acks, Timeout, TopicData),
     Data = vg_protocol:encode_request(?PRODUCE_REQUEST, RequestId, ?CLIENT_ID, Request),
 
-    {ok, RequestId, [<<(iolist_size(Data)):32/signed>>, Data],
+    {ok, RequestId, [<<(iolist_size(Data)):32/signed-integer>>, Data],
      State#state{corids = maps:put(RequestId, ?PRODUCE_REQUEST, CorIds),
                  request_counter = RequestCounter + 1}};
 handle_request(topics, #state {
@@ -108,7 +108,7 @@ handle_request(topics, #state {
                          } = State) ->
     RequestId = request_id(RequestCounter),
     Data = vg_protocol:encode_request(?TOPICS_REQUEST, RequestId, ?CLIENT_ID, <<>>),
-    {ok, RequestId, [<<(iolist_size(Data)):32/signed>>, Data],
+    {ok, RequestId, [<<(iolist_size(Data)):32/signed-integer>>, Data],
      State#state{corids = maps:put(RequestId, ?TOPICS_REQUEST, CorIds),
                  request_counter = RequestCounter + 1}}.
 

--- a/test/cleanup_SUITE.erl
+++ b/test/cleanup_SUITE.erl
@@ -4,6 +4,8 @@
 -include_lib("common_test/include/ct.hrl").
 -compile(export_all).
 
+-include("vg.hrl").
+
 all() ->
     [delete_policy].
 
@@ -31,8 +33,7 @@ delete_policy(_Config) ->
     vg:create_topic(Topic),
     ?assert(filelib:is_dir(TopicPartitionDir)),
 
-    RandomRecords = [#{crc => erlang:crc32(M),
-                       record => M}
+    RandomRecords = [#{record => M}
                       || M <- [crypto:strong_rand_bytes(60), crypto:strong_rand_bytes(60)]],
     vg:write(Topic, RandomRecords),
 

--- a/test/log_roll_SUITE.erl
+++ b/test/log_roll_SUITE.erl
@@ -4,6 +4,8 @@
 -include_lib("common_test/include/ct.hrl").
 -compile(export_all).
 
+-include("vg.hrl").
+
 all() ->
     [record_set_larger_than_max_segment].
 
@@ -31,8 +33,7 @@ record_set_larger_than_max_segment(_Config) ->
     vg:create_topic(Topic),
     ?assert(filelib:is_dir(TopicPartitionDir)),
 
-    RandomRecords = [#{crc => erlang:crc32(M),
-                        record => M}
+    RandomRecords = [#{record => M}
                       || M <- [crypto:strong_rand_bytes(60), crypto:strong_rand_bytes(60),
                                crypto:strong_rand_bytes(6), crypto:strong_rand_bytes(6),
                                crypto:strong_rand_bytes(60)]],


### PR DESCRIPTION
Now checksums the right content to match kafka and does less decoding (no need to match on the magic byte and attributes since we don't use them and they remain the same when written to disk).

fixes #35 