### PR TITLE
fix low offset lookups.

### DIFF
--- a/src/vg_index.erl
+++ b/src/vg_index.erl
@@ -35,7 +35,7 @@ find_in_index_(_, Id, BaseOffset, <<Offset:24/signed, Position:24/signed, _/bina
 find_in_index_(_, Id, BaseOffset, <<Offset:24/signed, _:24/signed, _:24/signed, _:24/signed, _/binary>>)
   when BaseOffset + Offset > Id ->
     0;
-find_in_index_(_, Id, BaseOffset, <<Offset:24/signed, Position:24/signed, Offset:24/signed, _:24/signed, _/binary>>)
+find_in_index_(_, Id, BaseOffset, <<_:24/signed, Position:24/signed, Offset:24/signed, _:24/signed, _/binary>>)
   when BaseOffset + Offset > Id ->
     Position;
 find_in_index_(Fd, Id, BaseOffset, <<_:24/signed, _:24/signed, Rest/binary>>) ->

--- a/src/vg_log_segments.erl
+++ b/src/vg_log_segments.erl
@@ -112,6 +112,10 @@ find_in_log(Log, Id, Position) ->
     {ok, _} = file:position(Log, Position),
     find_in_log(Log, Id, Position, file:read(Log, 12)).
 
+find_in_log(Log, Id, _Position, {ok, <<FileId:64/signed, _Size:32/signed>>}) when FileId > Id ->
+    %% we'll never succeed if this is the case, start scan over.
+    file:position(Log, 0),
+    find_in_log(Log, Id, 0, file:read(Log, 12));
 find_in_log(_Log, Id, Position, {ok, <<Id:64/signed, _Size:32/signed>>}) ->
     Position;
 find_in_log(Log, Id, Position, {ok, <<_:64/signed, Size:32/signed>>}) ->

--- a/test/topic_SUITE.erl
+++ b/test/topic_SUITE.erl
@@ -5,11 +5,13 @@
 -compile(export_all).
 
 all() ->
-    [creation, write].
+    [creation, write, index_bug].
 
 init_per_suite(Config) ->
     PrivDir = ?config(priv_dir, Config),
     lager:start(),
+    %% clear env from other suites
+    application:unload(vonnegut),
     application:load(vonnegut),
     application:load(partisan),
     application:set_env(partisan, partisan_peer_service_manager, partisan_default_peer_service_manager),
@@ -58,3 +60,38 @@ write(Config) ->
 
     {ok, #{record_set := Reply1}} = vg_client:fetch(Topic, R1 - 1),
     ?assertMatch([#{record := Anarchist}, #{record := Communist}], Reply1).
+
+index_bug(Config) ->
+    Topic = ?config(topic, Config),
+
+    %% write enough data to cause index creation but not two entries
+    {ok, _}  = vg_client:produce(Topic,
+                                 lists:duplicate(100, <<"123456789abcdef">>)),
+
+    %% fetch from 0 to make sure that they're all there
+    {ok, #{record_set := Reply}} = vg_client:fetch(Topic, 0),
+    ?assertEqual(100, length(Reply)),
+
+    %% now query for something before the first index marker
+    {ok, #{record_set := Reply2,
+           high_water_mark := HWM}} = vg_client:fetch(Topic, 10),
+
+    ?assertEqual(99, HWM),
+
+    %% this is a passing version before the bugfix
+    %% ?assertEqual([], Reply2).
+
+    ?assertEqual(90, length(Reply2)),
+
+    %% write enough more data for another entry to hit the second clause
+    {ok, _}  = vg_client:produce(Topic,
+                                 lists:duplicate(100, <<"123456789abcdef">>)),
+
+    {ok, #{record_set := Reply3}} = vg_client:fetch(Topic, 0),
+    ?assertEqual(200, length(Reply3)),
+
+    {ok, #{record_set := Reply4,
+           high_water_mark := HWM4}} = vg_client:fetch(Topic, 10),
+
+    ?assertEqual(199, HWM4),
+    ?assertEqual(190, length(Reply4)).


### PR DESCRIPTION
the issue here is that the index lookup matches miss cases where they ought to point at the start of the file and instead return the position in the first index entry.  they fail to consider the case where the record id is below the current topic offset in both the cases where there is a single entry and a few.

I'm worried about the second case that I've added, as I'm worried that it might be overly broad, but I can't think of a good counter example, and the worst case is that sometimes we'll start our scan from the start of a file.

I've also added another case to the log file scanning routine to notice that it's already scanned past (or started past already as is the case with the index lookup issue) and restarts the scan at 0.  This makes me just a bit paranoid.  It'd be a bit safer to check the CRC for the entry before we restart the scan to help combat infinite loops in the case of a corrupted offset.  I can add that if the consensus is that it's a real threat.