### PR TITLE
Enhance topic map

### DIFF
--- a/include/vg.hrl
+++ b/include/vg.hrl
@@ -30,7 +30,7 @@
 -define(topic_map, topic_map).
 
 -record(chain, {
-          name  :: binary(),
+          name  :: binary() | atom(),
           nodes :: [atom()] | undefined,
           head  :: {inet:ip_address() | inet:hostname(), inet:port_number()},
           tail  :: {inet:ip_address() | inet:hostname(), inet:port_number()}

--- a/src/vg_client_pool.erl
+++ b/src/vg_client_pool.erl
@@ -74,6 +74,7 @@ get_pool(Topic, RW) ->
                             Chain = choose_random_chain(),
                             Pool = make_pool_name(Chain, RW),
                             vg_client:ensure_topic(Pool, Topic),
+                            ets:insert(?topic_map, {Topic, Chain}),
                             {ok, Pool};
                         _ ->
                             lager:error("failed finding existing chain and"

--- a/src/vg_client_pool.erl
+++ b/src/vg_client_pool.erl
@@ -2,7 +2,6 @@
 
 -export([start/0,
          stop/0,
-         get_pool/0,
          get_pool/2,
          refresh_topic_map/0]).
 
@@ -25,11 +24,11 @@ start() ->
                 [{Host, Port} | _] ->
                     start_pool(metadata, #{ip => Host,
                                            port => Port}),
-                    {ok, {Chains, Topics}} = vg_client:metadata(),
+                    {ok, {_, Chains}} = vg_client:topics(),
                     maybe_init_ets(),
                     _ = start_pools(Chains),
                     application:set_env(vonnegut, chains, Chains),
-                    refresh_topic_map(Topics, Chains),
+                    refresh_topic_map(),
                     ok
             end;
         _ ->
@@ -38,56 +37,74 @@ start() ->
 
 start_pools(Chains) ->
     [begin
-         lager:debug("starting chain: ~p", [Chain]),
+         lager:info("starting chain: ~p ~p", [Name, C]),
          HeadName = make_pool_name(Name, write),
-         {HeadHost, HeadPort} = Chain#chain.head,
-         start_pool(HeadName, #{ip => HeadHost,
+         start_pool(HeadName, #{ip => binary_to_list(HeadHost),
                                 port => HeadPort}),
+         TailHost =
+             case TailHost0 of
+                 <<"solo">> -> HeadHost;
+                 _ -> TailHost0
+             end,
          TailName = make_pool_name(Name, read),
-         {TailHost, TailPort} = Chain#chain.tail,
-         start_pool(TailName, #{ip => TailHost,
+         start_pool(TailName, #{ip => binary_to_list(TailHost),
                                 port => TailPort})
      end
-     || {Name, Chain} <- maps:to_list(Chains)].
+     || #{name := Name,
+          head := {HeadHost, HeadPort},
+          tail := {TailHost0, TailPort}} = C  <- Chains].
 
 refresh_topic_map() ->
-    {ok, {Chains, Topics}} = vg_client:metadata(),
-    _ = start_pools(Chains),
-    refresh_topic_map(Topics, Chains).
-
-refresh_topic_map(Topics, Chains) ->
-    lager:debug("refreshing client topic map", []),
+    %% get a list of chains
+    {ok, {_, Chains}} = vg_client:topics(),
     maybe_init_ets(clean),
-    [make_pool_name(Chain, read) || Chain <- maps:keys(Chains)],
-    _ = [ets:insert(?topic_map, {Topic, Chain}) || {Topic, Chain} <- maps:to_list(Topics)].
-
-get_pool() ->
-    Key = ets:first(?topic_map),
-    get_pool(Key, read).
+    ets:insert(?topic_map, {chains, Chains}).
 
 get_pool(Topic, RW) ->
-    get_pool(Topic, RW, first).
-
-get_pool(Topic, RW, Try) ->
     %% at some point we should handle retries here for when the topic
     %% list is being refreshed.
     case ets:lookup(?topic_map, Topic) of
         [] ->
-            case {RW, Try} of
-                {write, first} ->
-                    vg_client:ensure_topic(Topic),
-                    refresh_topic_map(),
-                    get_pool(Topic, RW, second);
-                {read, first} ->
-                    refresh_topic_map(),
-                    get_pool(Topic, RW, second);
-                {_, second} ->
-                    lager:error("failed finding existing chain and creating new topic=~p", [Topic]),
-                    {error, not_found}
+            case try_all_chains(Topic) of
+                {ok, Pool} ->
+                    {ok, Pool};
+                {error, not_found} ->
+                    case RW of
+                        write ->
+                            Chain = choose_random_chain(),
+                            Pool = make_pool_name(Chain, RW),
+                            vg_client:ensure_topic(Pool, Topic),
+                            {ok, Pool};
+                        _ ->
+                            lager:error("failed finding existing chain and"
+                                        " creating new topic=~p", [Topic]),
+                            {error, not_found}
+                    end
             end;
         [{_, Chain}] ->
             Pool = make_pool_name(Chain, RW),
             lager:debug("found chain for topic=~p on pool=~p", [Topic, Pool]),
+            {ok, Pool}
+    end.
+
+choose_random_chain() ->
+    [{_, Chains}] = ets:lookup(?topic_map, chains),
+    #{name := Name} = lists:nth(rand:uniform(length(Chains)), Chains),
+    Name.
+
+try_all_chains(Topic) ->
+    [{_, Chains}] = ets:lookup(?topic_map, chains),
+    try_all_chains(Topic, Chains).
+
+try_all_chains(_Topic, []) ->
+    {error, not_found};
+try_all_chains(Topic, [#{name := Name}|T]) ->
+    Pool = make_pool_name(Name, read),
+    case shackle:call(Pool, {topics, [Topic]}) of
+        {ok, {0, _}} ->
+            try_all_chains(Topic, T);
+        {ok, {1, _}} ->
+            ets:insert(?topic_map, {Topic, Name}),
             {ok, Pool}
     end.
 

--- a/src/vg_log_segments.erl
+++ b/src/vg_log_segments.erl
@@ -4,6 +4,7 @@
 -export([init_table/0,
          load_all/2,
          insert/3,
+         local/2,
          find_log_segment/3,
          find_active_segment/2,
          find_segment_offset/3,
@@ -37,6 +38,14 @@ load_all(Topic, Partition) ->
 
 insert(Topic, Partition, SegmentId) ->
     ets:insert(?SEGMENTS_TABLE, {Topic, Partition, SegmentId}).
+
+local(Topic, Partition) ->
+    case ets:select(?SEGMENTS_TABLE, [{?LOG_SEGMENT_MATCH_PATTERN(Topic, Partition),
+                                       ?LOG_SEGMENT_GUARD(0),
+                                       ?LOG_SEGMENT_RETURN}]) of
+        [] -> false;
+        _ -> true
+    end.
 
 -spec find_log_segment(Topic, Partition, RecordId) -> integer() when
       Topic     :: binary(),

--- a/src/vg_protocol.erl
+++ b/src/vg_protocol.erl
@@ -174,7 +174,7 @@ decode_array(DecodeFun, <<Length:32/signed-integer, Rest/binary>>) ->
     decode_array(DecodeFun, Length, Rest, []).
 
 decode_array(_, 0, Rest, Acc) ->
-    {Acc, Rest};
+    {lists:reverse(Acc), Rest};
 decode_array(DecodeFun, N, Rest, Acc) ->
     case DecodeFun(Rest) of
         {Element, Rest1} ->

--- a/test/topic_SUITE.erl
+++ b/test/topic_SUITE.erl
@@ -119,7 +119,6 @@ many(Config) ->
 
     Start = erlang:monotonic_time(milli_seconds),
     [begin
-         timer:sleep(100),
          N = integer_to_binary(N0),
          Topic = vg_test_utils:create_random_name(<<"many-topic-", N/binary>>),
          %% adding a record to the topic will create it under current settings


### PR DESCRIPTION
the initial topic sync plan was really bad, it basically enumerates a list of all of the topics and reprocesses them.  This works really poorly as the number of topics scales.  This isn't meant to be the ultimate solution, but it scales a little bit better than before.