### PR TITLE
fix a mixup with my understanding of how metadata requests worked

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,6 +3,7 @@
  [debug_info,
   warn_untyped_records,
   warnings_as_errors,
+  nowarn_export_all,
   {parse_transform, lager_transform}]}.
 
 {cover_enabled, true}.

--- a/src/vg_client.erl
+++ b/src/vg_client.erl
@@ -36,7 +36,8 @@ metadata(Topics) ->
 
 -spec ensure_topic(Topic :: vg:topic()) ->
                           {ok, {Chains :: vg_cluster_mgr:chains_map(),
-                                Topics :: vg_cluster_mgr:topics_map()}}.
+                                Topics :: vg_cluster_mgr:topics_map()}} |
+                          {error, Reason :: term()}.
 ensure_topic(Topic) ->
     %% always use the metadata topic, creation happens inside via a global process.
     shackle:call(metadata, {metadata, [Topic]}, ?TIMEOUT).

--- a/src/vg_client.erl
+++ b/src/vg_client.erl
@@ -3,7 +3,7 @@
 %%-behavior(shackle_client). ?
 
 -export([metadata/0, metadata/1,
-         ensure_topic/2,
+         ensure_topic/1,
          topics/0, topics/2,
          fetch/1, fetch/2, fetch/3,
          produce/2,
@@ -34,11 +34,12 @@ metadata() ->
 metadata(Topics) ->
     shackle:call(metadata, {metadata, Topics}).
 
--spec ensure_topic(Pool :: atom(), Topic :: vg:topic()) ->
+-spec ensure_topic(Topic :: vg:topic()) ->
                           {ok, {Chains :: vg_cluster_mgr:chains_map(),
                                 Topics :: vg_cluster_mgr:topics_map()}}.
-ensure_topic(Pool, Topic) ->
-    shackle:call(Pool, {metadata, [Topic]}, ?TIMEOUT).
+ensure_topic(Topic) ->
+    %% always use the metadata topic, creation happens inside via a global process.
+    shackle:call(metadata, {metadata, [Topic]}, ?TIMEOUT).
 
 -spec fetch(Topic)
            -> {ok, #{high_water_mark := integer(),

--- a/test/vg_test_utils.erl
+++ b/test/vg_test_utils.erl
@@ -3,4 +3,4 @@
 -compile(export_all).
 
 create_random_name(Name) ->
-    <<Name/binary, "-", (erlang:integer_to_binary(crypto:rand_uniform(0, 1000000)))/binary>>.
+    <<Name/binary, "-", (erlang:integer_to_binary(rand:uniform(1000000)))/binary>>.


### PR DESCRIPTION
metadata requests are backed by the cluster manager, which is a global
process.  so we should just use them to both find topics and create
them, if we don't know where they are in the cluster.

additionally, this patch contains a few fixes for running on OTP20.

fixes #61 