### PR TITLE
Replicas of 1 fix and docker changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,28 @@
-FROM ubuntu:16.04
+FROM tsloughter/erlang-alpine:20.0.1 as builder
 
-RUN apt-get update && \
-    apt-get install --no-install-recommends -y libssl-dev && \
-    rm -rf /var/lib/apt/lists/*
+WORKDIR /usr/src/app
+COPY . /usr/src/app
 
-RUN mkdir -p /opt/vonnegut
+RUN rebar3 as prod tar
+
+RUN mkdir -p /opt/rel
+RUN tar -zxvf /usr/src/app/_build/prod/rel/*/*.tar.gz -C /opt/rel
+
+FROM alpine:3.6
+
+RUN apk add --no-cache openssl-dev ncurses
+
+WORKDIR /opt/vonnegut
 
 ENV RELX_REPLACE_OS_VARS true
+ENV NODE 127.0.0.1
+ENV CHAIN_NAME chain1
+ENV REPLICAS 1
+ENV DISCOVERY_DOMAIN local
 
-ADD ./vonnegut.tar.gz /opt/vonnegut
+COPY --from=builder /opt/rel /opt/vonnegut
 
-EXPOSE 8080 8080
+EXPOSE 5555 5555
 
 ENTRYPOINT ["/opt/vonnegut/bin/vonnegut"]
 

--- a/config/prod_vm.args
+++ b/config/prod_vm.args
@@ -1,4 +1,4 @@
--name vonnegut
+-name vonnegut@${NODE}
 
 -setcookie vonnegut
 

--- a/rebar.config
+++ b/rebar.config
@@ -25,7 +25,7 @@
         partisan,
         lager]}.
 
-{relx, [{release, {vonnegut, "0.0.1"},
+{relx, [{release, {vonnegut, "0.4.0"},
          [vonnegut]},
 
         {dev_mode, true},
@@ -53,7 +53,10 @@
  {prod, [{relx, [{sys_config, "config/prod_sys.config"},
                  {vm_args, "config/prod_vm.args"},
                  {dev_mode, false},
-                 {include_erts, true}]}]}
+                 {include_erts, true},
+                 {include_src, false},
+                 {debug_info, strip}
+                ]}]}
  ]}.
 
 {ct_opts, [{ct_hooks, [cth_surefire]}]}.

--- a/src/vg_chain_state.erl
+++ b/src/vg_chain_state.erl
@@ -132,7 +132,7 @@ code_change(_, _OldState, Data, _) ->
 
 %% assume we expect to find at least 1 node if using srv discovery
 role(_Node, _, 1, _) ->
-    head;
+    solo;
 role(_Node, [], _, {srv, _}) ->
     undefined;
 role(Node, [Node], _, {srv, _}) ->

--- a/src/vg_chain_state.erl
+++ b/src/vg_chain_state.erl
@@ -64,7 +64,7 @@ inactive(state_timeout, connect, Data=#data{name=Name,
                                             cluster_type=ClusterType}) ->
     {Members, AllNodes} = join(ClusterType),
     lager:info("cluster_type=~p members=~p all_nodes=~p", [ClusterType, Members, AllNodes]),
-    case role(node(), Members, ClusterType) of
+    case role(node(), Members, Replicas, ClusterType) of
         solo ->
             lager:info("at=chain_complete role=solo requested_size=1", []),
             lager:info("at=start_cluster_mgr role=solo"),
@@ -131,17 +131,19 @@ code_change(_, _OldState, Data, _) ->
 %% Internal functions
 
 %% assume we expect to find at least 1 node if using srv discovery
-role(_Node, [], {srv, _}) ->
-    undefined;
-role(Node, [Node], {srv, _}) ->
-    undefined;
-role(_Node, [], local) ->
-    solo;
-role(Node, [Node], local) ->
-    solo;
-role(Node, [Node | _], _) ->
+role(_Node, _, 1, _) ->
     head;
-role(Node, Nodes, _) ->
+role(_Node, [], _, {srv, _}) ->
+    undefined;
+role(Node, [Node], _, {srv, _}) ->
+    undefined;
+role(_Node, [], _, local) ->
+    solo;
+role(Node, [Node], _, local) ->
+    solo;
+role(Node, [Node | _], _, _) ->
+    head;
+role(Node, Nodes, _, _) ->
     case lists:reverse(Nodes) of
         [Node | _] ->
             tail;

--- a/src/vonnegut.app.src
+++ b/src/vonnegut.app.src
@@ -1,6 +1,6 @@
 {application, vonnegut,
  [{description, "An OTP application"},
-  {vsn, "0.1.0"},
+  {vsn, "0.4.0"},
   {registered, []},
   {mod, {vonnegut_app, []}},
   {applications,


### PR DESCRIPTION
If replicas is set to 1 then the node should always mark itself as solo right away. 

This PR also moves the docker image to alpine and uses the multi-stage builds for creating the image.