### PR TITLE
solo shouldn't require being 127.0.0.1, important for compose

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -25,7 +25,7 @@
         partisan,
         lager]}.
 
-{relx, [{release, {vonnegut, "0.4.0"},
+{relx, [{release, {vonnegut, "0.5.0"},
          [vonnegut]},
 
         {dev_mode, true},

--- a/src/vg_chain_state.erl
+++ b/src/vg_chain_state.erl
@@ -68,7 +68,10 @@ inactive(state_timeout, connect, Data=#data{name=Name,
         solo ->
             lager:info("at=chain_complete role=solo requested_size=1", []),
             lager:info("at=start_cluster_mgr role=solo"),
-            vonnegut_sup:start_cluster_mgr(solo, []),
+            ClientPort = vg_config:port(),
+            PartisanPort = application:get_env(partisan, peer_port, 10200),
+            [N, H] = string:split(atom_to_list(node()), "@"),
+            vonnegut_sup:start_cluster_mgr(solo, [{list_to_atom(N), H, PartisanPort, ClientPort}]),
             {next_state, active, Data#data{members=Members,
                                            role=solo,
                                            all_nodes=[],
@@ -155,6 +158,10 @@ next_node(tail, _, _) ->
     tail;
 next_node(head, _, [_, Next | _]) ->
     Next;
+next_node(_, Node, []) ->
+    Node;
+next_node(_, _, [N]) ->
+    N;
 next_node(_, Node, Nodes) ->
     find_next(Node, Nodes).
 

--- a/src/vonnegut.app.src
+++ b/src/vonnegut.app.src
@@ -1,6 +1,6 @@
 {application, vonnegut,
  [{description, "An OTP application"},
-  {vsn, "0.4.0"},
+  {vsn, "0.5.0"},
   {registered, []},
   {mod, {vonnegut_app, []}},
   {applications,


### PR DESCRIPTION
Before this change if the replicas was set to 1 it would realize it was running in `solo` mode and assume everything was on `127.0.0.1`. This meant using it in solo mode with like docker-compose would fail. The patch has it use the host part of the node name instead.