### PR TITLE
separate ensure and metadata

### DIFF
--- a/include/vg.hrl
+++ b/include/vg.hrl
@@ -19,6 +19,7 @@
 %% non-kafka extension
 -define(TOPICS_REQUEST, 1000).
 -define(FETCH2_REQUEST, 1001).
+-define(ENSURE_REQUEST, 1002).
 
 -define(NONE_ERROR, 0).
 -define(FETCH_DISALLOWED_ERROR, 129).

--- a/src/vg_client_pool.erl
+++ b/src/vg_client_pool.erl
@@ -84,12 +84,14 @@ get_pool(Topic, RW) ->
     %% list is being refreshed.
     case ets:lookup(?topic_map, Topic) of
         [] ->
-            %% TODO: this creates a topic on a read, which isn't great
-            case vg_client:ensure_topic(Topic) of
+            case vg_client:metadata([Topic]) of
                 {ok, {_Chains, #{Topic := Chain}}} ->
                     ets:insert(?topic_map, {Topic, Chain}),
                     Pool = make_pool_name(Chain, RW),
                     {ok, Pool};
+                %% topic doesn't exist
+                {ok, {_, #{}}} ->
+                    {error, not_found};
                 {error, Reason} ->
                     {error, Reason}
             end;

--- a/src/vg_conn.erl
+++ b/src/vg_conn.erl
@@ -120,6 +120,43 @@ handle_request(?METADATA_REQUEST, _, Data, CorrelationId, Socket) ->
     Topics0 = vg_protocol:decode_metadata_request(Data),
     Topics = case Topics0 of
                  [] -> vg_topics:all();
+                 _ -> Topics0
+             end,
+    lager:info("at=metadata_request topics=~p", [Topics]),
+    %% need to return all nodes and start giving nodes an integer id
+    {_, Chains, _} = vg_cluster_mgr:get_map(),
+    {_, Nodes} = maps:fold(fun(_Name, #chain{head={HeadHost, HeadPort},
+                                             tail={TailHost, TailPort}}, {Id, Acc}) ->
+                               HeadNode = {Id, {HeadHost, HeadPort}},
+                               case {TailHost, TailPort} of
+                                   {HeadHost, HeadPort} ->
+                                       %% same as head node
+                                       TailNode = {Id, {TailHost, TailPort}},
+                                       {Id+1, [HeadNode, TailNode | Acc]};
+                                   _ ->
+                                       TailNode = {Id+1, {TailHost, TailPort}},
+                                       {Id+2, [HeadNode, TailNode | Acc]}
+                               end
+                        end, {0, []}, Chains),
+    TopicMetadata =
+        lists:flatten([try
+                           #chain{head=Head,
+                                  tail=Tail} = vg_topics:get_chain(Topic),
+                           {HeadId, _} = lists:keyfind(Head, 2, Nodes),
+                           {TailId, _} = lists:keyfind(Tail, 2, Nodes),
+                           {0, Topic, [{0, HeadId, 0, [TailId], []}]}
+                       catch _:_ ->
+                               %% if the topic doesn't exist, omit it,
+                               %% so we can check for non-existent topics.
+                               []
+                       end || Topic <- Topics]),
+    Response = vg_protocol:encode_metadata_response(Nodes, TopicMetadata),
+    Size = erlang:iolist_size(Response) + 4,
+    gen_tcp:send(Socket, [<<Size:32/signed-integer, CorrelationId:32/signed-integer>>, Response]);
+handle_request(?ENSURE_REQUEST, _, Data, CorrelationId, Socket) ->
+    Topics0 = vg_protocol:decode_metadata_request(Data),
+    Topics = case Topics0 of
+                 [] -> vg_topics:all();
                  _ -> [vg:ensure_topic(T) || T <- Topics0], Topics0
              end,
     lager:info("at=metadata_request topics=~p", [Topics]),

--- a/test/topic_SUITE.erl
+++ b/test/topic_SUITE.erl
@@ -27,7 +27,7 @@ end_per_suite(Config) ->
 init_per_testcase(_, Config) ->
     ok = vg_client_pool:start(#{reconnect => false}),
     Topic = vg_test_utils:create_random_name(<<"topic_SUITE_default_topic">>),
-    vg:create_topic(Topic),
+    {ok, _} = vg_client:ensure_topic(Topic),
     [{topic, Topic} | Config].
 
 end_per_testcase(_, Config) ->
@@ -118,8 +118,8 @@ limit(Config) ->
 index_limit(Config) ->
     Topic = ?config(topic, Config),
 
-    {ok, _}  = vg_client:produce(Topic,
-                                 lists:duplicate(100, <<"123456789abcdef">>)),
+    {ok, _} = vg_client:produce(Topic,
+                                lists:duplicate(100, <<"123456789abcdef">>)),
 
     {ok, #{Topic := #{0 := #{record_set := Reply}}}} = vg_client:fetch(Topic, 0),
     ?assertEqual(100, length(Reply)),
@@ -158,7 +158,8 @@ many(Config) ->
          Topic = vg_test_utils:create_random_name(<<"many-topic-", N/binary>>),
          %% adding a record to the topic will create it under current settings
          ct:pal("adding to topic: ~p", [Topic]),
-         {ok, _}  = vg_client:produce(Topic, [<<"woo">>])
+         {ok, _} = vg_client:ensure_topic(Topic),
+         {ok, _} = vg_client:produce(Topic, [<<"woo">>])
      end || N0 <- lists:seq(1, TopicCount)],
     Duration = erlang:monotonic_time(milli_seconds) - Start,
     ct:pal("creating ~p topics took ~p ms", [TopicCount, Duration]),

--- a/test/z_cluster_SUITE.erl
+++ b/test/z_cluster_SUITE.erl
@@ -194,6 +194,7 @@ all() ->
 bootstrap(Config) ->
     %% just create topics when written to for now
     %% do(vg, create_topic, [<<"foo">>]),
+    {ok, _} = vg_client:ensure_topic(<<"foo">>),
     {ok, R} = vg_client:produce(<<"foo">>, <<"bar">>),
     {ok, R1} = vg_client:fetch(<<"foo">>),
     ct:pal("r ~p ~p", [R, R1]),
@@ -202,6 +203,7 @@ bootstrap(Config) ->
 
 roles(Config) ->
     Topic = <<"foo">>,
+    {ok, _} = vg_client:ensure_topic(Topic),
     %% write some stuff to have something to read.
     [vg_client:produce(Topic, <<"bar", (integer_to_binary(N))/binary>>)
      || N <- lists:seq(1, 20)],
@@ -234,6 +236,7 @@ roles(Config) ->
     Config.
 
 acks(Config) ->
+    {ok, _} = vg_client:ensure_topic(<<"foo">>),
     [vg_client:produce(<<"foo">>, <<"bar", (integer_to_binary(N))/binary>>)
      || N <- lists:seq(1, 20)],
 
@@ -242,6 +245,7 @@ acks(Config) ->
 
 concurrent_fetch(_Config) ->
     Topic = vg_test_utils:create_random_name(<<"cluster_concurrent_fetch">>),
+    {ok, _} = vg_client:ensure_topic(Topic),
     RandomRecords = [crypto:strong_rand_bytes(60), crypto:strong_rand_bytes(60),
                      crypto:strong_rand_bytes(6), crypto:strong_rand_bytes(6),
                      crypto:strong_rand_bytes(60)],
@@ -275,6 +279,10 @@ concurrent_perf(_Config) ->
     Topic1 = vg_test_utils:create_random_name(<<"cluster_concurrent_perf1">>),
     Topic2 = vg_test_utils:create_random_name(<<"cluster_concurrent_perf2">>),
     Topic3 = vg_test_utils:create_random_name(<<"cluster_concurrent_perf3">>),
+
+    {ok, _} = vg_client:ensure_topic(Topic1),
+    {ok, _} = vg_client:ensure_topic(Topic2),
+    {ok, _} = vg_client:ensure_topic(Topic3),
 
     RandomRecords = [crypto:strong_rand_bytes(60), crypto:strong_rand_bytes(60),
                      crypto:strong_rand_bytes(6), crypto:strong_rand_bytes(6),


### PR DESCRIPTION
this PR makes it possible to get the metadata of a topic without
creating it, which is causing some bugs in nucleus.  it makes it so
that ensure_topic needs to be called before topic creation, and
metadata will not create a topic when called.

metadata now filters out non-existent topics in its return, so if the
topic metadata is missing from the reply, the topic does not exist.