### PR TITLE
adjust for special meaning of 0 in file:sendfile

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -8,10 +8,10 @@
                       %% with direct we do not need to set the # replicas expected
                       %% {replicas, "2"}
 
-                      {port, 5555}]}
+                      {port, 5555}]},
 
              %% client config for if we want to use only the vonnegut client
-             {client, [{endpoint, [{"127.0.0.1", 5555}]}]},
+             {client, [{endpoint, [{"127.0.0.1", 5555}]}]}
             ]},
 
  {partisan, [{peer_port, 10200},

--- a/src/vg_conn.erl
+++ b/src/vg_conn.erl
@@ -359,7 +359,11 @@ fetch(Topic, Partition, Offset, MaxBytes, Limit) ->
 
 %% a fetch response is a list of iolists and tuples representing file chunks to send through sendfile
 do_send(FetchResults, Socket) ->
-    lists:foreach(fun({File, Position, Bytes}) ->
+    lists:foreach(fun({_File, _Position, 0}) ->
+                          %% have to noop here, as we're already framed,
+                          %% and 0 has special meaning for sendfile
+                          noop;
+                     ({File, Position, Bytes}) ->
                        sendfile(File, Position, Bytes, Socket);
                      (noop) ->
                        noop;


### PR DESCRIPTION
Balazs was running into a pseduo race where a particular interleaving of reads and writes would produce a vg_client crash.  The issue here is that sendfile takes an argument of 0 bytes to mean "send everything".  The race here is that when the fetch assesses the size of the file and generates the framing, it's 0-length, which gets sent to sendfile, but my the time sendfile is called, the file has been written to, to sendfile sends the accumulated data in the topic without any framing, crashing the client.

To fix this, we simply treat a sendfile return of 0 as a noop and don't send any data.