### PR TITLE
don't crash if another node has chains started

### DIFF
--- a/src/vg_cluster_mgr.erl
+++ b/src/vg_cluster_mgr.erl
@@ -154,7 +154,11 @@ ensure_topic(ChainName, Topic, State=#state{topics=Topics,
                     {{error, chain_not_found}, State};
                 #chain{nodes=Nodes} ->
                     %% start topic process on all nodes in the chain
-                    [{ok, _} = vg_topics_sup:start_child(Node, Topic, [0]) || Node <- Nodes],
+                    [case vg_topics_sup:start_child(Node, Topic, [0]) of
+                         {ok, _} -> ok;
+                         {error,{already_started, _}} -> ok;
+                         {error, Reason} -> exit({error, Reason})
+                     end || Node <- Nodes],
 
                     Topics1 = maps:put(Topic, ChainName, Topics),
                     {ok, State#state{topics=Topics1,


### PR DESCRIPTION
When the vonnegut node that's running the cluster manager crashes but the rest of the chain does not, the node can never recover because the other node is already running topics when the manager tries to start them. 

TODO: this needs a test