### PR TITLE
Fix startup index lookup

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -24,7 +24,7 @@
         {shackle, {git, "https://github.com/lpgauth/shackle", {branch, "master"}}},
         partisan,
         lager,
-
+        recon,
         {oc_google_reporter, {git, "https://github.com/tsloughter/oc_google_reporter.git", {branch, "master"}}},
         {opencensus, {git, "https://github.com/census-instrumentation/opencensus-erlang.git", {branch, "master"}}},
 

--- a/test/z_cluster_SUITE.erl
+++ b/test/z_cluster_SUITE.erl
@@ -34,7 +34,7 @@ init_per_suite(Config) ->
                                    {application, load, [lager]},
                                    {application, set_env,
                                     [lager, handlers,
-                                     [{lager_console_backend, [info]},
+                                     [{lager_console_backend, [{level, info}]},
                                       {lager_file_backend,
                                        [{file, "console"++N++".log"}, {level, debug}]}]]},
                                    {application, ensure_all_started, [lager]},


### PR DESCRIPTION
index determination of small logs was broken on startup.  unless the current index was correct about the offset, I'm not actually sure that it ever worked.

part of the issue was that `file:pread/3` doesn't actually set the position reliably (the docs state that it's undefined after a `pread` call.  part of the issue reading too much data in initially.  part of the issue was the match being for incorrect sizes, I think?

Anyway, when we have time it'd be awesome to write a PropEr test that opens, closes, reads, writes, etc, etc.
