### PR TITLE
move to using vg more, improve coverage

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,6 +7,7 @@
   {parse_transform, lager_transform}]}.
 
 {cover_enabled, true}.
+{cover_opts, [verbose]}.
 {cover_export_enabled, true}.
 
 {coveralls_coverdata    , "_build/test/cover/ct.coverdata"}.

--- a/src/vg.erl
+++ b/src/vg.erl
@@ -2,9 +2,9 @@
 
 -export([create_topic/1,
          ensure_topic/1,
-         write/2,
-         fetch/2,
-         fetch/1]).
+         write/3,
+         fetch/1, fetch/2,
+         fetch/5]).
 
 -include("vg.hrl").
 
@@ -20,25 +20,22 @@
 
 -spec create_topic(Topic :: topic()) -> ok.
 create_topic(Topic) ->
-    {ok, _} = vg_cluster_mgr:create_topic(Topic),
+    {ok, _Chain} = vg_cluster_mgr:create_topic(Topic),
     ok.
 
 -spec ensure_topic(Topic :: topic()) -> ok.
 ensure_topic(Topic) ->
-    case vg_cluster_mgr:create_topic(Topic) of
-        {ok, _} ->
-            ok;
-        {error, exists} ->
-            ok
-    end.
+    {ok, _Chain} = vg_cluster_mgr:ensure_topic(Topic),
+    ok.
 
--spec write(Topic, Record) -> ok | {error, any()} when
+-spec write(Topic, Partition, Record) -> ok | {error, any()} when
       Topic :: topic(),
+      Partition :: non_neg_integer(),
       Record :: binary() | record_set().
-write(Topic, Record) when is_binary(Record) ->
-    vg_active_segment:write(Topic, 0, [#{record => Record}]);
-write(Topic, RecordSet) when is_list(RecordSet) ->
-    vg_active_segment:write(Topic, 0, RecordSet).
+write(Topic, Partition, Record) when is_binary(Record) ->
+    vg_active_segment:write(Topic, Partition, [#{record => Record}]);
+write(Topic, Partition, RecordSet) when is_list(RecordSet) ->
+    vg_active_segment:write(Topic, Partition, RecordSet).
 
 fetch(Topic) ->
     fetch(Topic, 0).
@@ -55,8 +52,62 @@ fetch(Topic, Offset) ->
     File = vg_utils:log_file(Topic, Partition, SegmentId),
     Size = filelib:file_size(File),
     {ok, Fd} = file:open(File, [read, binary, raw]),
-    {ok, [Data]} = file:pread(Fd, [{Position, Size}]),
-    file:close(Fd),
-    {ok, #{high_water_mark => vg_topics:lookup_hwm(Topic, Partition),
-           partition => 0,
-           record_set => vg_protocol:decode_record_set(Data, [])}}.
+    try
+        {ok, [Data]} = file:pread(Fd, [{Position, Size}]),
+        {ok, #{high_water_mark => vg_topics:lookup_hwm(Topic, Partition),
+               partition => 0,
+               record_set => vg_protocol:decode_record_set(Data, [])}}
+    after
+        file:close(Fd)
+    end.
+
+%% fetch/5 is a special form that only returns sizes and positions for
+%% later framing and sending
+
+%% A fetch of offset -1 returns Limit number of the records up to the
+%% high watermark
+fetch(Topic, Partition, -1, MaxBytes, Limit) ->
+    Offset = vg_topics:lookup_hwm(Topic, Partition),
+    fetch(Topic, Partition, erlang:max(0, Offset - Limit + 1), MaxBytes, Limit);
+fetch(Topic, Partition, Offset, MaxBytes, Limit) ->
+    {SegmentId, Position} = vg_log_segments:find_segment_offset(Topic, Partition, Offset),
+    Fetch =
+        case Limit of
+            -1 ->
+                unlimited;
+            _ ->
+                {EndSegmentId, EndPosition} =
+                    vg_log_segments:find_segment_offset(Topic, Partition, Offset + Limit),
+                case SegmentId of
+                    %% max on this segment, limit fetch
+                    EndSegmentId ->
+                        {limited, EndPosition - Position};
+                    %% some higher segment, unlimited fetch
+                    _ ->
+                        unlimited
+                end
+        end,
+
+    lager:info("at=fetch_request topic=~s partition=~p offset=~p segment_id=~p position=~p",
+              [Topic, Partition, Offset, SegmentId, Position]),
+
+    File = vg_utils:log_file(Topic, Partition, SegmentId),
+    SendBytes =
+        case Fetch of
+            unlimited ->
+                filelib:file_size(File) - Position;
+            {limited, Limited} ->
+                Limited
+        end,
+    Bytes =
+        case MaxBytes of
+            0 -> SendBytes;
+            _ -> min(SendBytes, MaxBytes)
+        end,
+    ErrorCode = 0,
+    HighWaterMark = vg_topics:lookup_hwm(Topic, Partition),
+    Response = vg_protocol:encode_fetch_topic_response(Partition, ErrorCode, HighWaterMark, Bytes),
+
+    lager:debug("sending hwm=~p bytes=~p", [HighWaterMark, Bytes]),
+    {erlang:iolist_size(Response)+Bytes, Response, {File, Position, Bytes}}.
+

--- a/test/cleanup_SUITE.erl
+++ b/test/cleanup_SUITE.erl
@@ -38,7 +38,7 @@ delete_policy(_Config) ->
 
     RandomRecords = [#{record => M}
                       || M <- [crypto:strong_rand_bytes(60), crypto:strong_rand_bytes(60)]],
-    vg:write(Topic, RandomRecords),
+    vg:write(Topic, Partition, RandomRecords),
 
     %% Verify 2 segments have been created
     Segment0 = filename:join([TopicPartitionDir, "00000000000000000000.log"]),

--- a/test/log_roll_SUITE.erl
+++ b/test/log_roll_SUITE.erl
@@ -38,7 +38,7 @@ record_set_larger_than_max_segment(_Config) ->
                       || M <- [crypto:strong_rand_bytes(60), crypto:strong_rand_bytes(60),
                                crypto:strong_rand_bytes(6), crypto:strong_rand_bytes(6),
                                crypto:strong_rand_bytes(60)]],
-    vg:write(Topic, RandomRecords),
+    vg:write(Topic, 0, RandomRecords),
 
     %% Total size of a 60 byte record when written to log becomes 86 bytes
     %% Since index interval is 24 and 86 > 24, 1 index entry of 6 bytes should exist for each as well

--- a/test/topic_SUITE.erl
+++ b/test/topic_SUITE.erl
@@ -6,7 +6,8 @@
 
 all() ->
     [creation, write_empty, write, index_bug, limit, index_limit,
-     startup_index_correctness, many, verify_lazy_load].
+     startup_index_correctness, many, verify_lazy_load,
+     local_client_test].
 
 init_per_suite(Config) ->
     PrivDir = ?config(priv_dir, Config),
@@ -275,3 +276,16 @@ verify_lazy_load(_Config) ->
                                  lists:duplicate(100, <<"123456789abcdef">>)),
 
     ?assertNotEqual(undefined, erlang:whereis(Name)).
+
+local_client_test(Config) ->
+    Topic = ?config(topic, Config),
+    vg:write(Topic, 0, <<"foo">>),
+    {ok, Ret} = vg:fetch(Topic),
+    ?assertMatch(#{high_water_mark := 0,
+                   partition := 0,
+                   record_set :=
+                       [#{crc := 656261833,
+                          id := 0,
+                          record := <<"foo">>}]},
+                 Ret),
+    ok.

--- a/test/z_cluster_SUITE.erl
+++ b/test/z_cluster_SUITE.erl
@@ -100,7 +100,7 @@ start_lager() ->
 
 swap_lager(Nodes) ->
     %% for deeper debugging, sometimes it's nice to be able to toggle this off
-    Disable = true,
+    Disable = false,
     case Disable of
         true ->
             ok;


### PR DESCRIPTION
this moves all of the interaction logic for the log files into the "local client", and has the connection use it instead of doing the work itself.  `fetch/5` is pretty tightly coupled to both sides, but I hoped that having the code for it and the other fetch in the same place would make them both more likely to be kept up to date.

This is precursor work for updating the proper statem test, which I've been working on in another branch.