### PR TITLE
include host in search for next node

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -36,7 +36,7 @@
         prometheus,
         elli_prometheus]}.
 
-{relx, [{release, {vonnegut, "git"},
+{relx, [{release, {vonnegut, "0.8.0"},
          [vonnegut]},
 
         {dev_mode, true},

--- a/src/vg_chain_state.erl
+++ b/src/vg_chain_state.erl
@@ -110,9 +110,11 @@ inactive(state_timeout, connect, Data=#data{name=Name,
                     %% monitor next link in the chain
                     NextNode = next_node(Role, node(), Members),
                     case string:split(atom_to_list(NextNode), "@") of
-                        [N, _H] ->
-                            {_, Host, _, Port} = lists:keyfind(list_to_atom(N), 1, AllNodes),
-                            vg_client_pool:start_pool(next_brick, #{ip => Host,
+                        [N, H] ->
+                            [Port] = [P || {N1, H1, _, P} <- AllNodes,
+                                           N1 =:= list_to_atom(N),
+                                           H1 =:= H],
+                            vg_client_pool:start_pool(next_brick, #{ip => H,
                                                                     port => Port});
                         _ ->
                             ok

--- a/src/vonnegut.app.src
+++ b/src/vonnegut.app.src
@@ -1,6 +1,6 @@
 {application, vonnegut,
  [{description, "Replicated append-only log."},
-  {vsn, git},
+  {vsn, "0.8.0"},
   {registered, []},
   {mod, {vonnegut_app, []}},
   {applications,


### PR DESCRIPTION
Also sets a version to 0.8.0. I like using the google cloudbuilder for vonnegut and right now it won't work with the `git` version trick.