### PR TITLE
adjust how hwm is accounted for internally

### DIFF
--- a/src/vg_topic_sup.erl
+++ b/src/vg_topic_sup.erl
@@ -36,7 +36,6 @@ init([Topic, Partitions]) ->
 %%====================================================================
 
 child_specs(Topic, Partition) ->
-    vg_log_segments:load_all(Topic, Partition),
     %% wait for the chain to be active?
     Next = vg_chain_state:next(),
     [#{id      => {Topic, Partition},

--- a/test/z_cluster_SUITE.erl
+++ b/test/z_cluster_SUITE.erl
@@ -345,19 +345,19 @@ roles_w_reconnect(Config) ->
 
     wait_for_nodes(Nodes1, 50), % wait a max of 5s
     timer:sleep(2000),
-    %% ok = wait_for_start(fun() -> vg_client:produce(<<"bar4">>, 0, 1) end),
+    %% ok = wait_for_start(fun() -> vg_client:produce(<<"bar9">>, 0, 1) end),
 
     ?assertMatch({error, 131}, vg_client:produce(<<"bar4">>, <<"ASDASDASDASDASDASDA">>)),
     %% not sure that I like the inconsistency here
-    ?assertMatch({ok, #{<<"bar4">> := #{0 := #{error_code := 129}}}},
-                 vg_client:fetch(<<"bar4">>, 0, 1)),
+    ?assertMatch({ok, #{<<"bar9">> := #{0 := #{error_code := 129}}}},
+                 vg_client:fetch(<<"bar9">>, 0, 1)),
 
     %% set reconnection on, it's checked dynamically
     application:set_env(vonnegut, swap_restart, true),
 
-    ?assertMatch({ok, 103}, vg_client:produce(<<"bar4">>, <<"ASDASDASDASDASDASDA">>)),
-    ?assertMatch({ok, #{<<"bar4">> := #{0 := #{error_code := 0}}}},
-                  vg_client:fetch(<<"bar4">>, 0, 1)),
+    ?assertMatch({ok, 100}, vg_client:produce(<<"bar9">>, <<"ASDASDASDASDASDASDA">>)),
+    ?assertMatch({ok, #{<<"bar9">> := #{0 := #{error_code := 0}}}},
+                  vg_client:fetch(<<"bar9">>, 0, 1)),
     Config.
 
 concurrent_fetch(_Config) ->
@@ -514,6 +514,7 @@ id_replication(Config) ->
     ?assertMatch({ok, 52}, rpc:call(Tail, gen_server, call, [{via,gproc,{n,l,{<<"bar-n">>, 0}}}, {write, 53, R}, 5000])),
     %% note that we VVVV succeed with 53 even though the previous writes never went through head
     ?assertMatch({ok, 53}, vg_client:produce(Topic, <<"this should succeed on retry">>)),
+    ct:pal("~p", [vg_client:fetch(Topic, 50, 10)]),
     Config.
 
 wait_for_start(Thunk) ->


### PR DESCRIPTION
this is a bit of a fiddly refactor.  it's OK to reject it, but I think that it improves the understandability of the code a little bit.  

the main changes are tweaking the hwm paths to return the actual hwm, rather than what the active segment wants for its ID, and renaming active_segment.id to next id to better capture what it's used for.

I also moved segment table loading into active segment startup, since it felt weird to me that it was a side-effect of the supervisor child spec generation.

lastly, I moved a few things around with respect to how the hwm was updated and initialized for the topic, in the hopes of making it more clear what was happening from a high-level perspective.