### PR TITLE
fix index lookup bug and de-magic indexing

### DIFF
--- a/include/vg.hrl
+++ b/include/vg.hrl
@@ -4,6 +4,10 @@
 -define(MAGIC, 1).
 -define(API_VERSION, 1).
 
+-define(INDEX_ENTRY_SIZE, 8). % bytes
+-define(INDEX_OFFSET_BITS, 32).
+-define(INDEX_POS_BITS, 32).
+
 -define(PRODUCE_REQUEST, 0).
 -define(FETCH_REQUEST, 1).
 -define(METADATA_REQUEST, 3).

--- a/src/vg_index.erl
+++ b/src/vg_index.erl
@@ -3,6 +3,8 @@
 %% Position is the offset in [offset].log to find the log Id
 -module(vg_index).
 
+-include("vg.hrl").
+
 -export([find_in_index/3]).
 
 -spec find_in_index(Fd, BaseOffset, Id) -> integer() | not_found when
@@ -10,7 +12,7 @@
       BaseOffset :: integer(),
       Id         :: integer().
 find_in_index(Fd, BaseOffset, Id) ->
-    case file:read(Fd, 12) of
+    case file:read(Fd, (2 * ?INDEX_ENTRY_SIZE)) of
         {ok, Bytes} ->
             find_in_index_(Fd, Id, BaseOffset, Bytes);
         _ ->
@@ -22,24 +24,34 @@ find_in_index(Fd, BaseOffset, Id) ->
 find_in_index_(_, _, _, <<>>) ->
     0;
 %% special case for when below the first offset in a single entry index
-find_in_index_(_, Id, BaseOffset, <<Offset:32/unsigned, _:32/unsigned>>)
+find_in_index_(_, Id, BaseOffset, <<Offset:?INDEX_OFFSET_BITS/unsigned,
+                                    _Pos:?INDEX_POS_BITS/unsigned>>)
   when BaseOffset + Offset > Id->
     0;
-find_in_index_(_, _, _, <<_:32/unsigned, Position:32/unsigned>>) ->
+find_in_index_(_, _, _, <<_Offset:?INDEX_OFFSET_BITS/unsigned,
+                          Position:?INDEX_POS_BITS/unsigned>>) ->
     Position;
-find_in_index_(_, Id, BaseOffset, <<Offset:32/unsigned, Position:32/unsigned, _/binary>>)
+find_in_index_(_, Id, BaseOffset, <<Offset:?INDEX_OFFSET_BITS/unsigned,
+                                    Position:?INDEX_POS_BITS/unsigned, _/binary>>)
   when Id =:= BaseOffset + Offset ->
     Position;
 %% special case for below the first offset in a multi-entry index, but
 %% I worry that it might be overly broad.
-find_in_index_(_, Id, BaseOffset, <<Offset:32/unsigned, _:32/unsigned, _:32/unsigned, _:32/unsigned, _/binary>>)
+find_in_index_(_, Id, BaseOffset, <<Offset:?INDEX_OFFSET_BITS/unsigned,
+                                    _Pos:?INDEX_POS_BITS/unsigned,
+                                    _Offset2:?INDEX_OFFSET_BITS/unsigned,
+                                    _Pos2:?INDEX_POS_BITS/unsigned, _/binary>>)
   when BaseOffset + Offset > Id ->
     0;
-find_in_index_(_, Id, BaseOffset, <<_:32/unsigned, Position:32/unsigned, Offset:32/unsigned, _:32/unsigned, _/binary>>)
-  when BaseOffset + Offset > Id ->
+find_in_index_(_, Id, BaseOffset, <<_Offset:?INDEX_OFFSET_BITS/unsigned,
+                                    Position:?INDEX_POS_BITS/unsigned,
+                                    Offset2:?INDEX_OFFSET_BITS/unsigned,
+                                    _Pos2:?INDEX_POS_BITS/unsigned, _/binary>>)
+  when BaseOffset + Offset2 > Id ->
     Position;
-find_in_index_(Fd, Id, BaseOffset, <<_:32/unsigned, _:32/unsigned, Rest/binary>>) ->
-    case file:read(Fd, 6) of
+find_in_index_(Fd, Id, BaseOffset, <<_Offset:?INDEX_OFFSET_BITS/unsigned,
+                                     _Pos:?INDEX_POS_BITS/unsigned, Rest/binary>>) ->
+    case file:read(Fd, ?INDEX_ENTRY_SIZE) of
         {ok, Bytes} ->
             find_in_index_(Fd, Id, BaseOffset, <<Rest/binary, Bytes/binary>>);
         _ ->

--- a/src/vg_log_segments.erl
+++ b/src/vg_log_segments.erl
@@ -179,7 +179,8 @@ new_index_log_files(TopicDir, Id) ->
     {ok, LogFile} = vg_utils:open_append(LogFilename),
     {IndexFile, LogFile}.
 
-
+%% consider moving this to vg_index, but then we might need to figure
+%% out some other, cleaner way to do the create new case
 last_in_index(TopicDir, IndexFilename, SegmentId) ->
     case file:open(IndexFilename, [read, binary]) of
         {error, enoent} when SegmentId =:= 0 ->
@@ -193,8 +194,8 @@ last_in_index(TopicDir, IndexFilename, SegmentId) ->
             {-1, 0};
         {ok, Index} ->
             try
-                case file:pread(Index, {eof, -8}, 8) of
-                    {ok, <<Offset:32/signed, Position:32/signed>>} ->
+                case file:pread(Index, {eof, -?INDEX_ENTRY_SIZE}, ?INDEX_ENTRY_SIZE) of
+                    {ok, <<Offset:?INDEX_OFFSET_BITS/signed, Position:?INDEX_POS_BITS/signed>>} ->
                         {Offset, Position};
                     _ ->
                         {-1, 0}


### PR DESCRIPTION
there were a few more places where we needed to fetch the larger amounts.   this wasn't causing any corruption to the index, it was just causing some bad and failed index lookups, which would all fail back to a slow scanning path, or return and index that was far too low for larger files.

I also took the opportunity to add some defines to hopefully make the code clearer and make it easier to change in the future, if needed.