### PR TITLE
only return the last recordbatch in a segment if it contains the offset

### DIFF
--- a/include/vg.hrl
+++ b/include/vg.hrl
@@ -2,7 +2,11 @@
 -define(MAX_REQUEST_ID, 2147483647).
 
 -define(MAGIC_TWO, 2).
--define(API_VERSION, 1).
+-define(API_VERSION, 2).
+
+%% a recordbatch starts with FirstOffset:64, Length:32
+%% so 12 is an often used constant when reading batches
+-define(OFFSET_AND_LENGTH_BYTES, 12).
 
 -define(INDEX_ENTRY_SIZE, 8). % bytes
 -define(INDEX_OFFSET_BITS, 32).

--- a/src/vg.erl
+++ b/src/vg.erl
@@ -110,8 +110,7 @@ fetch(Topic, Offset) ->
     fetch(Topic, 0, Offset, -1).
 
 fetch(Topic, Partition, Offset, Count) ->
-    {_, _, {File, Position, Bytes}} =
-        fetch(Topic, Partition, Offset, 0, Count),
+    {_, _, {File, Position, Bytes}} = fetch(Topic, Partition, Offset, 0, Count),
     {ok, Fd} = file:open(File, [read, binary, raw]),
     try
         {ok, [Data]} = file:pread(Fd, [{Position, Bytes}]),
@@ -158,10 +157,9 @@ fetch(Topic, Partition, Offset, MaxBytes, Limit) ->
         end,
 
     lager:info("at=fetch_request topic=~s partition=~p offset=~p segment_id=~p position=~p",
-              [Topic, Partition, Offset, SegmentId, Position]),
+               [Topic, Partition, Offset, SegmentId, Position]),
 
     File = vg_utils:log_file(Topic, Partition, SegmentId),
-
     SendBytes =
         case Fetch of
             unlimited ->
@@ -175,9 +173,7 @@ fetch(Topic, Partition, Offset, MaxBytes, Limit) ->
             _ -> min(SendBytes, MaxBytes)
         end,
     ErrorCode = 0,
-
     Response = vg_protocol:encode_fetch_topic_response(Partition, ErrorCode, HWM, Bytes),
-
     lager:debug("sending hwm=~p bytes=~p", [HWM, Bytes]),
     {erlang:iolist_size(Response)+Bytes, Response, {File, Position, Bytes}}.
 

--- a/src/vg_active_segment.erl
+++ b/src/vg_active_segment.erl
@@ -48,8 +48,6 @@
 
 -define(ACTIVE_SEG(Topic, Partition), {via, gproc, {n, l, {active, Topic, Partition}}}).
 
--define(SIZE_OFFSET_LENGTH, 12).
-
 start_link(Topic, Partition, NextBrick) ->
     case gen_server:start_link(?ACTIVE_SEG(Topic, Partition), ?MODULE, [Topic, Partition, NextBrick],
                                [{hibernate_after, timer:minutes(5)}]) of % hibernate after 5 minutes with no messages
@@ -270,7 +268,7 @@ write_record_batch(#{last_offset_delta := LastOffsetDelta,
                                                           partition=Partition,
                                                           next_id=Id,
                                                           byte_count=ByteCount}) ->
-    Size = Size0 + ?SIZE_OFFSET_LENGTH,
+    Size = Size0 + ?OFFSET_AND_LENGTH_BYTES,
     NextId = Id + LastOffsetDelta + 1,
     State1 = #state{pos=Position1,
                     log_fd=LogFile} = maybe_roll(Size, State),


### PR DESCRIPTION
Fixes an issue where vonnegut would return the last record batch in a segment even if it didn't contain the requested starting offset. This change has it check if, when the search hits the last batch in a segment, the batch actually contains the id, or if we should start from after that segment.