### PR TITLE
Allow Endpoint as String

### DIFF
--- a/include/vg.hrl
+++ b/include/vg.hrl
@@ -1,4 +1,5 @@
 -define(CLIENT_ID, "vg_client").
+-define(DEFAULT_PORT, 5555).
 -define(MAX_REQUEST_ID, 2147483647).
 
 -define(MAGIC_TWO, 2).


### PR DESCRIPTION
Accepts "host:port" or "host" for endpoints in a client config, making it easier to accept config
values from environment variables.